### PR TITLE
changed protocol to use https

### DIFF
--- a/lib/google_directions.rb
+++ b/lib/google_directions.rb
@@ -7,8 +7,7 @@ require 'openssl'
 require 'base64'
 
 class GoogleDirections
-  VERSION   = '0.1.6.5'
-  BASE_URL  = 'http://maps.googleapis.com'
+  BASE_URL  = 'https://maps.googleapis.com'
   BASE_PATH = '/maps/api/directions/xml'
   DEFAULT_OPTIONS = {
     :language => :en,

--- a/lib/google_directions/version.rb
+++ b/lib/google_directions/version.rb
@@ -1,4 +1,3 @@
 class GoogleDirections
-  VERSION   = '0.1.6.6'
+  VERSION = '0.1.6.7'.freeze
 end
-

--- a/test/unit/google_directions_test.rb
+++ b/test/unit/google_directions_test.rb
@@ -13,7 +13,7 @@ class GoogleDirectionsTest < Minitest::Test
     assert_equal(4, directions.distance_in_miles)
     assert_equal(5, directions.drive_time_in_minutes)
     assert_equal(directions.successful?, true)
-    assert_equal('http://maps.googleapis.com/maps/api/directions/xml?language=en&alternative=true&sensor=false&mode=driving&origin=121+Gordonsville+Highway%2C+37030&destination=499+Gordonsville+Highway%2C+38563', directions.xml_call)
+    assert_equal('https://maps.googleapis.com/maps/api/directions/xml?language=en&alternative=true&sensor=false&mode=driving&origin=121+Gordonsville+Highway%2C+37030&destination=499+Gordonsville+Highway%2C+38563', directions.xml_call)
     # end_location > lat
 
     assert_equal orig, directions.origin
@@ -46,13 +46,13 @@ class GoogleDirectionsTest < Minitest::Test
   def test_steps
     directions = GoogleDirections.new("rue poissonnière, 75002 Paris", "51 rue de Turbigo, 75003 Paris France")
     assert_equal Array, directions.steps.class
-    assert_equal 4, directions.steps.size
+    assert_equal 5, directions.steps.size
   end
 
   def test_distance_text
     directions = GoogleDirections.new("Place du Maquis du Vercors PARIS-19EME", "rue poissoniere 75002 paris")
     assert_equal String, directions.distance_text.class
-    assert_equal "6.2 km", directions.distance_text
+    assert_equal "5.6 km", directions.distance_text
   end
 
   def test_zero_distance_text
@@ -62,7 +62,7 @@ class GoogleDirectionsTest < Minitest::Test
 
   def test_url_signing
     result = OpenStruct.new(read: "<xml><status>ERROR</status></xml>")
-    GoogleDirections.any_instance.expects(:open).with('http://maps.googleapis.com/maps/api/directions/xml?channel=channel&client=client&origin=27+Beemdenlaan%2C+2550+Kontich&destination=499+Gordonsville+Highway%2C+38563&signature=Naey6EZm6rFJ8AubrNdD4Xo-c-4=').returns(result)
+    GoogleDirections.any_instance.expects(:open).with('https://maps.googleapis.com/maps/api/directions/xml?channel=channel&client=client&origin=27+Beemdenlaan%2C+2550+Kontich&destination=499+Gordonsville+Highway%2C+38563&signature=Naey6EZm6rFJ8AubrNdD4Xo-c-4=').returns(result)
     directions = GoogleDirections.new("27 Beemdenlaan, 2550 Kontich", "499 Gordonsville Highway, 38563", private_key: "key", channel: "channel", client: "client")
     GoogleDirections.any_instance.unstub :open
   end


### PR DESCRIPTION
*  When not using signature auth, but auth over api key, you can't make a query to the http endpoint. Switching to the https endpoint should also not harm for signature auth (like liefery does this)
* Fixed multiple Version files
